### PR TITLE
Add example for a directly-connected gateway on IPv6.

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -4,7 +4,7 @@ desc: Examples | Netplan
 sitemap:
     priority: 1.0
     changefreq: 'monthly'
-    lastmod: 2018-04-11T17:20:30+00:00
+    lastmod: 2019-11-19T13:09:27+00:00
 ---
 <div class="p-strip--light is-bordered is-shallow">
   <div class="row">

--- a/examples.md
+++ b/examples.md
@@ -383,6 +383,22 @@ network:
         on-link: true
 ```
 
+For IPv6 the config would be very similar, with the notable difference being an additional scope: link host route to the router's address required:
+
+```yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    addresses: [ "2001:cafe:face:beef::dead:dead/64" ]
+    routes:
+      - to: "2001:cafe:face::1/128"
+        scope: link
+      - to: "::/0"
+        via: "2001:cafe:face::1"
+        on-link: true
+```
+
 ## Configuring source routing
 
 Route tables can be added to particular interfaces to allow routing between two networks:


### PR DESCRIPTION
Some users seem to have had a hard time to properly configure directly-connected gateways on ipv6 via netplan, as seen in the following askubuntu post:

https://askubuntu.com/questions/1148119/ipv6-default-route-not-being-set-netplan-ubuntu-18-04-2-lts

We have decided it would be best to include this particular example in the examples page (same change mirrored in the netplan examples/ directory).