### PR TITLE
Github action to run docker image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,15 @@
+name: Test docker image
+on: pull_request
+env:
+  DOCKER_BUILDKIT: 1
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build image
+      run: docker build --tag netplan-io .
+    - name: Run image
+      run: |
+        docker run -d -p 80:80 netplan-io
+        sleep 1 && curl --head --fail --retry-delay 5 --retry 10  --retry-connrefused http://localhost


### PR DESCRIPTION
## Done

- Current Dockerfile is not building, merging multistage builds PR will fix this issue and it will allow github actions to build correctly.
- Github action to test run docker image
- Requires merging first multistage builds for this project. This action uses `DOCKER_BUILDKIT` therefore if it doesn't use it, it will fail to build the image.