### PR TITLE
Disable renovate for ruby

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Build stage: Install ruby dependencies
 # ===
-FROM ruby:2.7 AS build-site
+FROM ruby:2.5 AS build-site
 WORKDIR /srv
 ADD . .
 RUN bundle install

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "config:base",
+    "docker:disable",
     "schedule:monthly",
     "group:all"
   ],


### PR DESCRIPTION
## Done

Disable renovate to avoid upgrades to ruby 2.7.