### PR TITLE
Update the reference section, add an SR-IOV example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -4,7 +4,7 @@ desc: Examples | Netplan
 sitemap:
     priority: 1.0
     changefreq: 'monthly'
-    lastmod: 2019-11-19T13:09:27+00:00
+    lastmod: 2020-04-29T12:19:10+00:00
 ---
 <div class="p-strip--light is-bordered is-shallow">
   <div class="row">
@@ -493,6 +493,27 @@ network:
         - "2001:dead:beef::2/64"
       gateway6: "2001:dead:beef::1"
 ```
+
+## Configuring SR-IOV Virtual Functions
+
+For SR-IOV network cards, it is possible to dynamically allocate Virtual Function interfaces for every configured Physical Function. In netplan, a VF is defined by having a link: property pointing to the parent PF.
+
+```yaml
+network:
+  version: 2
+  ethernets:
+    eno1:
+      mtu: 9000
+    enp1s16f1:
+      link: eno1
+      addresses : [ "10.15.98.25/24" ]
+    vf1:
+      match:
+        name: enp1s16f[2-3]
+      link: eno1
+      addresses : [ "10.15.99.25/24" ]
+```
+
 
 </div>
 <div class="col-4" markdown="1">

--- a/reference.md
+++ b/reference.md
@@ -4,7 +4,7 @@ desc: Reference | Netplan
 sitemap:
     priority: 1.0
     changefreq: 'monthly'
-    lastmod: 2018-12-13T17:02:34+00:00
+    lastmod: 2020-04-29T12:22:34+00:00
 ---
 <div class="p-strip--light is-bordered is-shallow">
   <div class="row">
@@ -16,6 +16,7 @@ sitemap:
 <div class="p-strip">
   <div class="row">
     <div class="col-8" markdown="1">
+
 
 
 ## Introduction
@@ -50,7 +51,7 @@ either of those directories shadows a file with the same name in
 The top-level node in a netplan configuration file is a ``network:`` mapping
 that contains ``version: 2`` (the YAML currently being used by curtin, MaaS,
 etc. is version 1), and then device definitions grouped by their type, such as
-``ethernets:``, ``wifis:``, or ``bridges:``. These are the types that our
+``ethernets:``, ``modems:``, ``wifis:``, or ``bridges:``. These are the types that our
 renderer can understand and are supported by our backends.
 
 Each type block contains device definitions as a map where the keys (called
@@ -63,12 +64,16 @@ configuration files. Their primary purpose is to serve as anchor names for
 composite devices, for example to enumerate the members of a bridge that is
 currently being defined.
 
+If an interface is defined with an ID in a configuration file; it will be
+brought up by the applicable renderer. To not have netplan touch an interface
+at all, it should be completely omitted from the netplan configuration files.
+
 There are two physically/structurally different classes of device definitions,
 and the ID field has a different interpretation for each:
 
 Physical devices
 
-:   (Examples: ethernet, wifi) These can dynamically come and go between
+:   (Examples: ethernet, modem, wifi) These can dynamically come and go between
     reboots and even during runtime (hotplugging). In the generic case, they
     can be selected by ``match:`` rules on desired properties, such as name/name
     pattern, MAC address, driver, or device paths. In general these will match
@@ -149,6 +154,10 @@ Virtual devices
 
 :    Enable wake on LAN. Off by default.
 
+``emit-lldp`` (bool)
+
+:    (networkd backend only) Whether to emit LLDP packets. Off by default.
+
 
 ## Common properties for all device types
 
@@ -156,8 +165,13 @@ Virtual devices
 
 :   Use the given networking backend for this definition. Currently supported are
     ``networkd`` and ``NetworkManager``. This property can be specified globally
-    in ``networks:``, for a device type (in e. g. ``ethernets:``) or
+    in ``network:``, for a device type (in e. g. ``ethernets:``) or
     for a particular device definition. Default is ``networkd``.
+
+    The ``renderer`` property has one additional acceptable value for vlan objects
+    (i. e. defined in ``vlans:``): ``sriov``. If a vlan is defined with the ``sriov``
+    renderer for an SR-IOV Virtual Function interface, this causes netplan to set
+    up a hardware VLAN filter for it. There can be only one defined per VF.
 
 ``dhcp4`` (bool)
 
@@ -178,6 +192,12 @@ Virtual devices
 
     Note that **``rdnssd``**(8) is required to use RDNSS with networkd. No extra
     software is required for NetworkManager.
+
+``ipv6-mtu`` (scalar)
+:   Set the IPv6 MTU (only supported with `networkd` backend). Note
+    that needing to set this is an unusual requirement.
+
+    **Requires feature: ipv6-mtu**
 
 ``ipv6-privacy`` (bool)
 
@@ -208,7 +228,7 @@ Virtual devices
 
 :   (networkd backend only) Designate the connection as "critical to the
     system", meaning that special care will be taken by systemd-networkd to
-    not release the IP from DHCP when the daemon is restarted.
+    not release the assigned IP when the daemon is restarted.
 
 ``dhcp-identifier`` (scalar)
 
@@ -244,6 +264,12 @@ Virtual devices
     but will not be addressable from the network.
 
     Example: ``addresses: [192.168.14.2/24, "2001:1::1/64"]``
+
+``ipv6-address-generation`` (scalar)
+
+:   Configure method for creating the address for use with RFC4862 IPv6
+    Stateless Address Autoconfiguration. Possible values are ``eui64``
+    or ``stable-privacy``.
 
 ``gateway4``, ``gateway6`` (scalar)
 
@@ -404,6 +430,17 @@ client processes as specified in the netplan YAML.
           on a preferred interface. Available for both the ``networkd`` and
           ``NetworkManager`` backends.
 
+     ``use-domains`` (scalar)
+     :    Takes a boolean, or the special value "route". When true, the domain 
+          name received from the DHCP server will be used as DNS search domain
+          over this link, similar to the effect of the Domains= setting. If set
+          to "route", the domain name received from the DHCP server will be 
+          used for routing DNS queries only, but not for searching, similar to
+          the effect of the Domains= setting when the argument is prefixed with
+          "~".
+
+          **Requires feature: dhcp-use-domains**
+
 
 ## Routing
 Complex routing is possible with netplan. Standard static routes as well
@@ -539,10 +576,77 @@ interfaces, as well as individual wifi networks, by means of the ``auth`` block.
      :    Password to use to decrypt the private key specified in
           ``client-key`` if it is encrypted.
 
+     ``phase2-auth`` (scalar)
+     :    Phase 2 authentication mechanism.
+
 
 ## Properties for device type ``ethernets:``
-Ethernet device definitions do not support any specific properties beyond the
-common ones described above.
+Ethernet device definitions, beyond common ones described above, also support
+some additional properties that can be used for SR-IOV devices.
+
+``link`` (scalar)
+
+:    (SR-IOV devices only) The ``link`` property declares the device as a
+     Virtual Function of the selected Physical Function device, as identified
+     by the given netplan id.
+
+Example:
+
+    ethernets:
+      enp1: {...}
+      enp1s16f1:
+        link: enp1
+
+``virtual-function-count`` (scalar)
+
+:    (SR-IOV devices only) In certain special cases VFs might need to be
+     configured outside of netplan. For such configurations ``virtual-function-count``
+     can be optionally used to set an explicit number of Virtual Functions for
+     the given Physical Function. If unset, the default is to create only as many
+     VFs as are defined in the netplan configuration. This should be used for special
+     cases only.
+
+## Properties for device type ``modems:``
+GSM/CDMA modem configuration is only supported for the ``NetworkManager`` backend. ``systemd-networkd`` does
+not support modems.
+
+``apn`` (scalar)
+:    Set the carrier APN (Access Point Name). This can be omitted if ``auto-config`` is enabled.
+
+``auto-config`` (bool)
+:    Specify whether to try and autoconfigure the modem by doing a lookup of the carrier
+     against the Mobile Broadband Provider database. This may not work for all carriers.
+
+``device-id`` (scalar)
+:    Specify the device ID (as given by the WWAN management service) of the modem to match.
+     This can be found using ``mmcli``.
+
+``network-id`` (scalar)
+:    Specify the Network ID (GSM LAI format). If this is specified, the device will not roam networks.
+
+``number`` (scalar)
+:    The number to dial to establish the connection to the mobile broadband network. (Deprecated for GSM)
+
+``password`` (scalar)
+:    Specify the password used to authenticate with the carrier network. This can be omitted
+     if ``auto-config`` is enabled.
+
+``pin`` (scalar)
+:    Specify the SIM PIN to allow it to operate if a PIN is set.
+
+``sim-id`` (scalar)
+:    Specify the SIM unique identifier (as given by the WWAN management service) which this
+     connection applies to. If given, the connection will apply to any device also allowed by
+     ``device-id`` which contains a SIM card matching the given identifier.
+
+``sim-operator-id`` (scalar)
+:    Specify the MCC/MNC string (such as "310260" or "21601") which identifies the carrier that
+     this connection should apply to. If given, the connection will apply to any device also
+     allowed by ``device-id`` and ``sim-id`` which contains a SIM card provisioned by the given operator.
+
+``username`` (scalar)
+:    Specify the username used to authentiate with the carrier network. This can be omitted if
+     ``auto-config`` is enabled.
 
 ## Properties for device type ``wifis:``
 Note that ``systemd-networkd`` does not natively support wifi, so you need
@@ -573,6 +677,28 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           ``ap`` (create an access point to which other devices can connect),
           and ``adhoc`` (peer to peer networks without a central access point).
           ``ap`` is only supported with NetworkManager.
+
+     ``bssid`` (scalar)
+     :    If specified, directs the device to only associate with the given
+          access point.
+
+     ``band`` (scalar)
+     :    Possible bands are ``5GHz`` (for 5GHz 802.11a) and ``2.4GHz``
+          (for 2.4GHz 802.11), do not restrict the 802.11 frequency band of the
+          network if unset (the default).
+
+     ``channel`` (scalar)
+     :    Wireless channel to use for the Wi-Fi connection. Because channel
+          numbers overlap between bands, this property takes effect only if
+          the ``band`` property is also set.
+
+``wakeonwlan`` (sequence of scalars)
+
+:    This enables WakeOnWLan on supported devices. Not all drivers support all
+     options. May be any combination of ``any``, ``disconnect``, ``magic_pkt``,
+     ``gtk_rekey_failure``, ``eap_identity_req``, ``four_way_handshake``,
+     ``rfkill_release`` or ``tcp`` (NetworkManager only). Or the exclusive
+     ``default`` flag (the default).
 
 ## Properties for device type ``bridges:``
 
@@ -741,14 +867,16 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
      ``up-delay`` (scalar)
      :    Specify the delay before enabling a link once the link is physically
           up. The default value is ``0``. This maps to the UpDelaySec= property
-          for the networkd renderer. If no time suffix is specified, the value
-          will be interpreted as milliseconds.
+          for the networkd renderer. This option is only valid for the miimon
+          link monitor. If no time suffix is specified, the value will be
+          interpreted as milliseconds.
 
      ``down-delay`` (scalar)
      :    Specify the delay before disabling a link once the link has been
           lost. The default value is ``0``. This maps to the DownDelaySec=
-          property for the networkd renderer. If no time suffix is specified,
-          the value will be interpreted as milliseconds.
+          property for the networkd renderer. This option is only valid for the
+          miimon link monitor. If no time suffix is specified, the value will
+          be interpreted as milliseconds.
 
      ``fail-over-mac-policy`` (scalar)
      :    Set whether to set all slaves to the same MAC address when adding
@@ -892,7 +1020,35 @@ Example:
       en-vpn:
         id: 2
         link: eno1
-        address: ...
+        addresses: ...
+
+
+## Backend-specific configuration parameters
+
+In addition to the other fields available to configure interfaces, some
+backends may require to record some of their own parameters in netplan,
+especially if the netplan definitions are generated automatically by the
+consumer of that backend. Currently, this is only used with ``NetworkManager``.
+
+``networkmanager`` (mapping)
+
+:    Keeps the NetworkManager-specific configuration parameters used by the
+     daemon to recognize connections.
+
+     ``name`` (scalar)
+     :    Set the display name for the connection.
+
+     ``uuid`` (scalar)
+     :    Defines the UUID (unique identifier) for this connection, as
+          generated by NetworkManager itself.
+
+     ``stable-id`` (scalar)
+     :    Defines the stable ID (a different form of a connection name) used
+          by NetworkManager in case the name of the connection might otherwise
+          change, such as when sharing connections between users.
+
+     ``device`` (scalar)
+     :    Defines the interface name for which this connection applies.
 
 
 ## Examples


### PR DESCRIPTION
Let's not merge it just yet, but it's good to stage it. The reference section is a bit out of date.
Ideally I'd like to merge it when we backport 0.99 to all the stable series, as now it's only available in 20.04.

## Done

[List of work items including drive-bys]

## QA

[List of steps to QA the new features or prove the bug has been resolved]

## Issue / Card

[List of links to GitHub issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
