### PR TITLE
Remove the 'requires feature' mentions for both modems: and SR-IOV

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -606,13 +606,9 @@ Example:
      VFs as are defined in the netplan configuration. This should be used for special
      cases only.
 
-     **Requires feature: sriov**
-
 ## Properties for device type ``modems:``
 GSM/CDMA modem configuration is only supported for the ``NetworkManager``
 backend. ``systemd-networkd`` does not support modems.
-
-**Requires feature: modems**
 
 ``apn`` (scalar)
 


### PR DESCRIPTION
Sadly, those two feature-flags didn't make it in time for 0.99. The *features* are there of course, but we don't have the flags for them in `netplan info`, which is unfortunate. So let's not confuse users. Since right now they might expect `netplan info` to report those - currently it won't, even though the features are available.

## Done

[List of work items including drive-bys]

## QA

[List of steps to QA the new features or prove the bug has been resolved]

## Issue / Card

[List of links to GitHub issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
