### PR TITLE
Correct documentation on dhcp overrides route-metric

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -426,7 +426,7 @@ client processes as specified in the netplan YAML.
 
      ``route-metric`` (scalar)
      :    Use this value for default metric for automatically-added routes.
-          Use this to prioritize routes for devices by setting a higher metric
+          Use this to prioritize routes for devices by setting a lower metric
           on a preferred interface. Available for both the ``networkd`` and
           ``NetworkManager`` backends.
 


### PR DESCRIPTION
A lower metric has higher priority over a higher one.

## Done

- Corrected paragraph on DHCP overrides where it is stated that a higher metric would give an interface priority.

## Issue / Card

Fixes #102.