### PR TITLE
Document the 'netplan try' command

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@ sitemap:
       <ul>
         <li><strong>netplan generate</strong>: Use <code>/etc/netplan</code> to generate the required configuration for the renderers.</li>
         <li><strong>netplan apply</strong>: Apply all configuration for the renderers, restarting them as necessary.</li>
-        <li><strong>netplan try</strong>: Apply configuration and wait for user confirmation. Roll back if network is broken or no confirmation is given.</li>
+        <li><strong>netplan try</strong>: Apply configuration and wait for user confirmation; will roll back if network is broken or no confirmation is given.</li>
       </ul>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@ sitemap:
       <ul>
         <li><strong>netplan generate</strong>: Use <code>/etc/netplan</code> to generate the required configuration for the renderers.</li>
         <li><strong>netplan apply</strong>: Apply all configuration for the renderers, restarting them as necessary.</li>
+        <li><strong>netplan try</strong>: Apply configuration and wait for user confirmation. Roll back if network is broken or no confirmation is given.</li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Done

Describe the `netplan try` command alongside `netplan generate` and `netplan apply`.

## QA

Executed `./run` and verified that the `netplan try` command is described in the "Commands" section on the frontpage.