### PR TITLE
Update docs and fix Wireguard formatting

### DIFF
--- a/src/reference.md
+++ b/src/reference.md
@@ -371,7 +371,9 @@ Virtual devices
 
 :   Set default gateway for IPv4/6, for manual address configuration. This
     requires setting ``addresses`` too. Gateway IPs must be in a form
-    recognized by **``inet_pton``**(3).
+    recognized by **``inet_pton``**(3). There should only be a single gateway
+    set in your global config, to make it unambiguous. If you need multiple
+    default routes, please define them via ``routing-policy``.
 
     Example for IPv4: ``gateway4: 172.16.0.1``
     Example for IPv6: ``gateway6: "2001:4::1"``
@@ -1159,17 +1161,20 @@ Examples:
 
 Wireguard specific keys:
 
-    ``mark`` (scalar) – since **0.100**
-    :   Firewall mark for outgoing WireGuard packets from this interface,
-        optional.
+``mark`` (scalar) – since **0.100**
 
-    ``port`` (scalar) – since **0.100**
-    :   UDP port to listen at or ``auto``. Optional, defaults to ``auto``.
+:   Firewall mark for outgoing WireGuard packets from this interface,
+     optional.
 
-    ``peers`` (sequence of mappings) – since **0.100**
-    :   A list of peers, each having keys documented below.
+``port`` (scalar) – since **0.100**
 
-    Example:
+:   UDP port to listen at or ``auto``. Optional, defaults to ``auto``.
+
+``peers`` (sequence of mappings) – since **0.100**
+
+:   A list of peers, each having keys documented below.
+
+Example:
 
     tunnels:
         wg0:
@@ -1190,35 +1195,39 @@ Wireguard specific keys:
                   keepalive: 22
                   endpoint: 5.4.3.2:1
 
-    ``endpoint`` (scalar) – since **0.100**
-    :   Remote endpoint IPv4/IPv6 address or a hostname, followed by a colon
-        and a port number.
+``endpoint`` (scalar) – since **0.100**
 
-    ``allowed-ips`` (sequence of scalars) – since **0.100**
-    :    A list of IP (v4 or v6) addresses with CIDR masks from which this peer
-         is allowed to send incoming traffic and to which outgoing traffic for
-         this peer is directed. The catch-all 0.0.0.0/0 may be specified for
-         matching all IPv4 addresses, and ::/0 may be specified for matching
-         all IPv6 addresses.
+:   Remote endpoint IPv4/IPv6 address or a hostname, followed by a colon
+    and a port number.
 
-    ``keepalive`` (scalar) – since **0.100**
-    :    An interval in seconds, between 1 and 65535 inclusive, of how often to
-         send an authenticated empty packet to the peer for the purpose of
-         keeping a stateful firewall or NAT mapping valid persistently. Optional.
+``allowed-ips`` (sequence of scalars) – since **0.100**
 
-    ``keys`` (mapping) – since **0.100**
-    :    Define keys to use for the Wireguard peers.
+:   A list of IP (v4 or v6) addresses with CIDR masks from which this peer
+    is allowed to send incoming traffic and to which outgoing traffic for
+    this peer is directed. The catch-all 0.0.0.0/0 may be specified for
+    matching all IPv4 addresses, and ::/0 may be specified for matching
+    all IPv6 addresses.
 
-         This field can be used as a mapping, where you can further specify the
-         ``public`` and ``shared`` keys.
+``keepalive`` (scalar) – since **0.100**
 
-         ``public`` (scalar) – since **0.100**
-         :    A base64-encoded public key, requried for Wireguard peers.
+:   An interval in seconds, between 1 and 65535 inclusive, of how often to
+    send an authenticated empty packet to the peer for the purpose of
+    keeping a stateful firewall or NAT mapping valid persistently. Optional.
 
-         ``shared`` (scalar) – since **0.100**
-         :    A base64-encoded preshared key. Optional for Wireguard peers.
-              When the ``systemd-networkd`` backend (v242+) is used, this can
-              also be an absolute path to a file containing the preshared key.
+``keys`` (mapping) – since **0.100**
+
+:   Define keys to use for the Wireguard peers.
+
+    This field can be used as a mapping, where you can further specify the
+    ``public`` and ``shared`` keys.
+
+    ``public`` (scalar) – since **0.100**
+    :    A base64-encoded public key, requried for Wireguard peers.
+
+    ``shared`` (scalar) – since **0.100**
+    :    A base64-encoded preshared key. Optional for Wireguard peers.
+         When the ``systemd-networkd`` backend (v242+) is used, this can
+         also be an absolute path to a file containing the preshared key.
 
 ## Properties for device type ``vlans:``
 


### PR DESCRIPTION
## Done

As applied in upstream github:
* Add note about gateway4/6 usage
* Fix formatting of Wireguard keys

## QA

Checked output/rendering of `./run`

## Issue / Card

https://askubuntu.com/questions/1287501/ubuntu-19-10-network-problem-with-public-ip-connects-but-cannot-send-anything/1287503#1287503

## Screenshots

[if relevant, include a screenshot]
