### PR TITLE
Update Github URL

### DIFF
--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -38,7 +38,7 @@
             <h4>Contribute</h4>
             <ul class="p-list">
                 <li class="p-list__item">
-                    <a class="p-link--external p-link--soft" href="https://github.com/CanonicalLtd/netplan">GitHub</a>
+                    <a class="p-link--external p-link--soft" href="https://github.com/canonical/netplan">GitHub</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
## Done

Updated Github URL: Repository was moved to the "canonical" organization, from "CanonicalLtd".
https://github.com/canonical/netplan

## QA

[List of steps to QA the new features or prove the bug has been resolved]

## Issue / Card

[List of links to GitHub issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
